### PR TITLE
Copy gemspec to /usr/src/app

### DIFF
--- a/1.7/onbuild/Dockerfile
+++ b/1.7/onbuild/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /usr/src/app
 
 ONBUILD ADD Gemfile /usr/src/app/
 ONBUILD ADD Gemfile.lock /usr/src/app/
+ONBUILD ADD *.gemspec .gemspec* /usr/src/app/
 ONBUILD RUN bundle install --system
 
 ONBUILD ADD . /usr/src/app

--- a/1.7/onbuild/Dockerfile
+++ b/1.7/onbuild/Dockerfile
@@ -1,5 +1,11 @@
 FROM jruby:1.7-jdk
 
+# Note that we `ADD .` **after** calling `bundle install`.
+# This pattern is taken from the official ruby-onbuild image.
+# It is this way is to make the most effective use of the build cache.
+# Putting `ADD .` before `bundle install` would be simpler, but then any change
+# in `.` would cause `bundle install` to run again, which is undesirable.
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
before `bundle install`.

This is:
- simpler
- solves problem that some Gemfiles reference a gemspec (See [Yehuda Katz post](http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/)) and this wasn't
  including the gemspec before running `bundle install`, resulting in:
  
  ```
  Trigger 2, RUN bundle install --system
  Step 0 : RUN bundle install --system
   ---> Running in 2cb8961c7e75
  Don't run Bundler as root. Bundler can ask for sudo if it is needed, and
  installing your bundle as root will break this application for all non-root
  users on this machine.
  There are no gemspecs at /usr/src/app.
  2015/02/02 20:53:06 The command [/bin/sh -c bundle install --system] returned a non-zero code: 15
  ```

Sample `Gemfile`:

``` ruby
source 'http://rubygems.org'

ruby '1.9.3', engine: 'jruby', engine_version: '1.7.19'

gemspec
```
