### PR TITLE
Simplify SHA1 handling (let sha1sum do all the work)

### DIFF
--- a/1.7/jdk/Dockerfile
+++ b/1.7/jdk/Dockerfile
@@ -2,18 +2,14 @@ FROM java:8-jdk
 ENV JRUBY_VERSION 1.7.19
 ENV JRUBY_SHA1 a3296d1ae9b9aa78825b8d65a0d2498b449eaa3d
 RUN mkdir /opt/jruby \
-  && curl -sSL https://s3.amazonaws.com/jruby.org/downloads/${JRUBY_VERSION}/jruby-bin-${JRUBY_VERSION}.tar.gz > /tmp/jruby.tar.gz \
-  && export JRUBY_SHA1_CALC=$(sha1sum /tmp/jruby.tar.gz | awk '{ print $1 }') \
-  && [ "$JRUBY_SHA1" != "$JRUBY_SHA1_CALC" ] && { \
-    echo "sha sum did not match expected: \"$JRUBY_SHA1\" - got: \"$JRUBY_SHA1_CALC\"" \
-    && exit 1;}; \
-  tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+  && curl -SL https://s3.amazonaws.com/jruby.org/downloads/${JRUBY_VERSION}/jruby-bin-${JRUBY_VERSION}.tar.gz -o /tmp/jruby.tar.gz \
+  && echo "$JRUBY_SHA1 /tmp/jruby.tar.gz" | sha1sum -c - \
+  && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
   && rm /tmp/jruby.tar.gz \
-  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1 \
-  && exit 0; }
+  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
 ENV PATH /opt/jruby/bin:$PATH
 
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-rdoc --no-ri' >> ~/.gemrc
 
 ENV GEM_HOME /usr/local/bundle
 ENV PATH $GEM_HOME/bin:$PATH

--- a/1.7/jre/Dockerfile
+++ b/1.7/jre/Dockerfile
@@ -2,18 +2,14 @@ FROM java:8-jre
 ENV JRUBY_VERSION 1.7.19
 ENV JRUBY_SHA1 a3296d1ae9b9aa78825b8d65a0d2498b449eaa3d
 RUN mkdir /opt/jruby \
-  && curl -sSL https://s3.amazonaws.com/jruby.org/downloads/${JRUBY_VERSION}/jruby-bin-${JRUBY_VERSION}.tar.gz > /tmp/jruby.tar.gz \
-  && export JRUBY_SHA1_CALC=$(sha1sum /tmp/jruby.tar.gz | awk '{ print $1 }') \
-  && [ "$JRUBY_SHA1" != "$JRUBY_SHA1_CALC" ] && { \
-    echo "sha sum did not match expected: \"$JRUBY_SHA1\" - got: \"$JRUBY_SHA1_CALC\"" \
-    && exit 1;}; \
-  tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+  && curl -SL https://s3.amazonaws.com/jruby.org/downloads/${JRUBY_VERSION}/jruby-bin-${JRUBY_VERSION}.tar.gz -o /tmp/jruby.tar.gz \
+  && echo "$JRUBY_SHA1 /tmp/jruby.tar.gz" | sha1sum -c - \
+  && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
   && rm /tmp/jruby.tar.gz \
-  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1 \
-  && exit 0; }
+  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
 ENV PATH /opt/jruby/bin:$PATH
 
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-rdoc --no-ri' >> ~/.gemrc
 
 ENV GEM_HOME /usr/local/bundle
 ENV PATH $GEM_HOME/bin:$PATH

--- a/9000/jdk/Dockerfile
+++ b/9000/jdk/Dockerfile
@@ -2,18 +2,14 @@ FROM java:8-jdk
 ENV JRUBY_VERSION 9.0.0.0.pre1
 ENV JRUBY_SHA1 fc2e037643f233332687bdd9d6d3405ed981c21c
 RUN mkdir /opt/jruby \
-  && curl -sSL https://s3.amazonaws.com/jruby.org/downloads/${JRUBY_VERSION}/jruby-bin-${JRUBY_VERSION}.tar.gz > /tmp/jruby.tar.gz \
-  && export JRUBY_SHA1_CALC=$(sha1sum /tmp/jruby.tar.gz | awk '{ print $1 }') \
-  && [ "$JRUBY_SHA1" != "$JRUBY_SHA1_CALC" ] && { \
-    echo "sha sum did not match expected: \"$JRUBY_SHA1\" - got: \"$JRUBY_SHA1_CALC\"" \
-    && exit 1;}; \
-  tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+  && curl -SL https://s3.amazonaws.com/jruby.org/downloads/${JRUBY_VERSION}/jruby-bin-${JRUBY_VERSION}.tar.gz -o /tmp/jruby.tar.gz \
+  && echo "$JRUBY_SHA1 /tmp/jruby.tar.gz" | sha1sum -c - \
+  && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
   && rm /tmp/jruby.tar.gz \
-  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1 \
-  && exit 0; }
+  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
 ENV PATH /opt/jruby/bin:$PATH
 
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-rdoc --no-ri' >> ~/.gemrc
 
 ENV GEM_HOME /usr/local/bundle
 ENV PATH $GEM_HOME/bin:$PATH

--- a/9000/jre/Dockerfile
+++ b/9000/jre/Dockerfile
@@ -2,18 +2,14 @@ FROM java:8-jre
 ENV JRUBY_VERSION 9.0.0.0.pre1
 ENV JRUBY_SHA1 fc2e037643f233332687bdd9d6d3405ed981c21c
 RUN mkdir /opt/jruby \
-  && curl -sSL https://s3.amazonaws.com/jruby.org/downloads/${JRUBY_VERSION}/jruby-bin-${JRUBY_VERSION}.tar.gz > /tmp/jruby.tar.gz \
-  && export JRUBY_SHA1_CALC=$(sha1sum /tmp/jruby.tar.gz | awk '{ print $1 }') \
-  && [ "$JRUBY_SHA1" != "$JRUBY_SHA1_CALC" ] && { \
-    echo "sha sum did not match expected: \"$JRUBY_SHA1\" - got: \"$JRUBY_SHA1_CALC\"" \
-    && exit 1;}; \
-  tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+  && curl -SL https://s3.amazonaws.com/jruby.org/downloads/${JRUBY_VERSION}/jruby-bin-${JRUBY_VERSION}.tar.gz -o /tmp/jruby.tar.gz \
+  && echo "$JRUBY_SHA1 /tmp/jruby.tar.gz" | sha1sum -c - \
+  && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
   && rm /tmp/jruby.tar.gz \
-  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1 \
-  && exit 0; }
+  && update-alternatives --install /usr/local/bin/ruby ruby /opt/jruby/bin/jruby 1
 ENV PATH /opt/jruby/bin:$PATH
 
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-rdoc --no-ri' >> ~/.gemrc
 
 ENV GEM_HOME /usr/local/bundle
 ENV PATH $GEM_HOME/bin:$PATH


### PR DESCRIPTION
Also, dropped `-s` on `curl` and added `-o` so we can get progress indication (those tarballs download _really_ slow in my testing), and fixed the `gemrc` appending to work with newer versions of Docker that actually set `HOME` appropriately. :+1:
