### PR TITLE
Add "libc6-dev" for the "pty" module

### DIFF
--- a/1.7/jdk/Dockerfile
+++ b/1.7/jdk/Dockerfile
@@ -1,4 +1,7 @@
 FROM java:8-jdk
+
+RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
 ENV JRUBY_VERSION 1.7.19
 ENV JRUBY_SHA1 a3296d1ae9b9aa78825b8d65a0d2498b449eaa3d
 RUN mkdir /opt/jruby \

--- a/1.7/jre/Dockerfile
+++ b/1.7/jre/Dockerfile
@@ -1,4 +1,7 @@
 FROM java:8-jre
+
+RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
 ENV JRUBY_VERSION 1.7.19
 ENV JRUBY_SHA1 a3296d1ae9b9aa78825b8d65a0d2498b449eaa3d
 RUN mkdir /opt/jruby \

--- a/9000/jdk/Dockerfile
+++ b/9000/jdk/Dockerfile
@@ -1,4 +1,7 @@
 FROM java:8-jdk
+
+RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
 ENV JRUBY_VERSION 9.0.0.0.pre2
 ENV JRUBY_SHA1 eca37f67ed13daf426f5e1f034209c4d0fb9ef10
 RUN mkdir /opt/jruby \

--- a/9000/jre/Dockerfile
+++ b/9000/jre/Dockerfile
@@ -1,4 +1,7 @@
 FROM java:8-jre
+
+RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
 ENV JRUBY_VERSION 9.0.0.0.pre2
 ENV JRUBY_SHA1 eca37f67ed13daf426f5e1f034209c4d0fb9ef10
 RUN mkdir /opt/jruby \


### PR DESCRIPTION
Before:

``` console
irb(main):001:0> require 'pty'
LoadError: Could not open library 'libutil' : libutil: cannot open shared object file: No such file or directory. Could not open library 'libutil.so' : libutil.so: cannot open shared object file: No such file or directory
    from /opt/jruby/lib/ruby/shared/ffi/library.rb:114:in `ffi_lib'
    from org/jruby/RubyArray.java:2412:in `map'
    from /opt/jruby/lib/ruby/shared/ffi/library.rb:84:in `ffi_lib'
    from /opt/jruby/lib/ruby/shared/pty.rb:10:in `LibUtil'
    from /opt/jruby/lib/ruby/shared/pty.rb:5:in `PTY'
    from /opt/jruby/lib/ruby/shared/pty.rb:3:in `(root)'
    from org/jruby/RubyKernel.java:1071:in `require'
    from /opt/jruby/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:1:in `(root)'
    from /opt/jruby/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:54:in `require'
    from org/jruby/RubyKernel.java:1107:in `eval'
    from (irb):1:in `evaluate'
    from org/jruby/RubyKernel.java:1507:in `loop'
    from org/jruby/RubyKernel.java:1270:in `catch'
    from org/jruby/RubyKernel.java:1270:in `catch'
    from /opt/jruby/bin/irb:13:in `(root)'
irb(main):002:0> 
```

After:

``` console
irb(main):001:0> require 'pty'
=> true
irb(main):002:0> 
```
