### PR TITLE
Add JRuby 1.7 JRE and JDK Alpine image

### DIFF
--- a/1.7/alpine-jdk/Dockerfile
+++ b/1.7/alpine-jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk-alpine
+FROM openjdk:8-jdk-alpine
 
 RUN apk add --no-cache \
       bash \

--- a/1.7/alpine-jdk/Dockerfile
+++ b/1.7/alpine-jdk/Dockerfile
@@ -1,0 +1,45 @@
+FROM java:8-jdk-alpine
+
+RUN apk add --no-cache \
+      bash \
+      libc6-compat
+
+ENV JRUBY_VERSION 1.7.25
+ENV JRUBY_SHA1 cd15aef419f97cff274491e53fcfb8b88ec36785
+
+RUN apk add --no-cache --virtual .build-deps \
+      curl \
+      tar \
+  && mkdir -p /opt/jruby \
+  && curl -fSL https://s3.amazonaws.com/jruby.org/downloads/${JRUBY_VERSION}/jruby-bin-${JRUBY_VERSION}.tar.gz -o /tmp/jruby.tar.gz \
+  && echo "$JRUBY_SHA1 */tmp/jruby.tar.gz" | sha1sum -c - \
+  && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+  && rm /tmp/jruby.tar.gz \
+  && ln -s /opt/jruby/bin/jruby /usr/local/bin/ruby \
+  && apk del .build-deps
+
+# set the jruby binaries in the path
+ENV PATH /opt/jruby/bin:$PATH
+
+# skip installing gem documentation
+RUN mkdir -p /opt/jruby/etc \
+    && { \
+        echo 'install: --no-document'; \
+        echo 'update: --no-document'; \
+    } >> /opt/jruby/etc/gemrc
+
+# install bundler, gem requires bash to work
+RUN gem install bundler
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+    BUNDLE_BIN="$GEM_HOME/bin" \
+    BUNDLE_SILENCE_ROOT_WARNING=1 \
+    BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+    && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+
+CMD [ "irb" ]

--- a/1.7/alpine-jre/Dockerfile
+++ b/1.7/alpine-jre/Dockerfile
@@ -1,0 +1,45 @@
+FROM java:8-jre-alpine
+
+RUN apk add --no-cache \
+      bash \
+      libc6-compat
+
+ENV JRUBY_VERSION 1.7.25
+ENV JRUBY_SHA1 cd15aef419f97cff274491e53fcfb8b88ec36785
+
+RUN apk add --no-cache --virtual .build-deps \
+      curl \
+      tar \
+  && mkdir -p /opt/jruby \
+  && curl -fSL https://s3.amazonaws.com/jruby.org/downloads/${JRUBY_VERSION}/jruby-bin-${JRUBY_VERSION}.tar.gz -o /tmp/jruby.tar.gz \
+  && echo "$JRUBY_SHA1 */tmp/jruby.tar.gz" | sha1sum -c - \
+  && tar -zx --strip-components=1 -f /tmp/jruby.tar.gz -C /opt/jruby \
+  && rm /tmp/jruby.tar.gz \
+  && ln -s /opt/jruby/bin/jruby /usr/local/bin/ruby \
+  && apk del .build-deps
+
+# set the jruby binaries in the path
+ENV PATH /opt/jruby/bin:$PATH
+
+# skip installing gem documentation
+RUN mkdir -p /opt/jruby/etc \
+    && { \
+        echo 'install: --no-document'; \
+        echo 'update: --no-document'; \
+    } >> /opt/jruby/etc/gemrc
+
+# install bundler, gem requires bash to work
+RUN gem install bundler
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+    BUNDLE_BIN="$GEM_HOME/bin" \
+    BUNDLE_SILENCE_ROOT_WARNING=1 \
+    BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+    && chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+
+CMD [ "irb" ]

--- a/1.7/alpine-jre/Dockerfile
+++ b/1.7/alpine-jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache \
       bash \


### PR DESCRIPTION
Add missing JRuby 1.7 JRE and JDK Alpine based images, they are most likely the same as the JRuby 9k ones.
