### PR TITLE
Change the base image from java to openjdk

### DIFF
--- a/1.7/jdk/Dockerfile
+++ b/1.7/jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/1.7/jre/Dockerfile
+++ b/1.7/jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9000/alpine-jdk/Dockerfile
+++ b/9000/alpine-jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk-alpine
+FROM openjdk:8-jdk-alpine
 
 RUN apk add --no-cache \
       bash \

--- a/9000/alpine-jre/Dockerfile
+++ b/9000/alpine-jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache \
       bash \

--- a/9000/jdk/Dockerfile
+++ b/9000/jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9000/jre/Dockerfile
+++ b/9000/jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM openjdk:8-jre
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The Java image was deprecated in favor of the OpenJDK and it will stop being maintained at the end of the year (2016-12-31). This change addresses the issue and shouldn't affect any image as the Java image is running OpenJDK.
