### PR TITLE
support arm64 architecture

### DIFF
--- a/9000/jdk/Dockerfile
+++ b/9000/jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk
+FROM arm64v8/openjdk:8-jdk
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9000/jre/Dockerfile
+++ b/9000/jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM arm64v8/openjdk:8-jre
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I build jruby dockerfile to support arm64 from arm64v8/openjdk:8-jdk and arm64v8/openjdk:8-jre-alpine success,but I don't know this file https://s3.amazonaws.com/jruby.org/downloads/9.1.12.0/jruby-bin-9.1.12.0.tar.gz -o /tmp/jruby.tar.gz whether or not support arm64 architecture. so I need some message about support arm64 architecture.