### PR TITLE
CI: Drop unused sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 services:
   - docker
 


### PR DESCRIPTION
This PR removes the now-unused `sudo: false` Travis directive.