### PR TITLE
Switch openjdk images to eclipse-temurin

### DIFF
--- a/9.2/jdk11/Dockerfile
+++ b/9.2/jdk11/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-buster
+FROM eclipse-temurin:11-jdk
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9.2/jdk17/Dockerfile
+++ b/9.2/jdk17/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-buster
+FROM eclipse-temurin:17-jdk
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9.2/jdk8/Dockerfile
+++ b/9.2/jdk8/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk
+FROM eclipse-temurin:8-jdk
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9.2/jre11/Dockerfile
+++ b/9.2/jre11/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-buster
+FROM eclipse-temurin:11-jre
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9.2/jre8/Dockerfile
+++ b/9.2/jre8/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9.3/jdk11/Dockerfile
+++ b/9.3/jdk11/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-buster
+FROM eclipse-temurin:11-jdk
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9.3/jdk17/Dockerfile
+++ b/9.3/jdk17/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-buster
+FROM eclipse-temurin:17-jdk
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9.3/jdk8/Dockerfile
+++ b/9.3/jdk8/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk
+FROM eclipse-temurin:8-jdk
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9.3/jre11/Dockerfile
+++ b/9.3/jre11/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-buster
+FROM eclipse-temurin:11-jre
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9.3/jre8/Dockerfile
+++ b/9.3/jre8/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
See https://github.com/docker-library/openjdk/pull/495

Fixes #79