### PR TITLE
Include GNU make in docker images to avoid issues while installing native gems

### DIFF
--- a/9.2/jdk11/Dockerfile
+++ b/9.2/jdk11/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:11-jdk-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.2.21.0
 ENV JRUBY_SHA256 dbf05fca4f61bd7d5131d9b83c5f4d1a249213c474b82def37e82013969c8b8a

--- a/9.2/jdk17/Dockerfile
+++ b/9.2/jdk17/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17-jdk-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.2.21.0
 ENV JRUBY_SHA256 dbf05fca4f61bd7d5131d9b83c5f4d1a249213c474b82def37e82013969c8b8a

--- a/9.2/jdk8/Dockerfile
+++ b/9.2/jdk8/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:8-jdk-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.2.21.0
 ENV JRUBY_SHA256 dbf05fca4f61bd7d5131d9b83c5f4d1a249213c474b82def37e82013969c8b8a

--- a/9.2/jre11/Dockerfile
+++ b/9.2/jre11/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:11-jre-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.2.21.0
 ENV JRUBY_SHA256 dbf05fca4f61bd7d5131d9b83c5f4d1a249213c474b82def37e82013969c8b8a

--- a/9.2/jre8/Dockerfile
+++ b/9.2/jre8/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:8-jre-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.2.21.0
 ENV JRUBY_SHA256 dbf05fca4f61bd7d5131d9b83c5f4d1a249213c474b82def37e82013969c8b8a

--- a/9.3/jdk11/Dockerfile
+++ b/9.3/jdk11/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:11-jdk-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.3.9.0
 ENV JRUBY_SHA256 251e6dd8d1d2f82922c8c778d7857e1bef82fe5ca2cf77bc09356421d0b05ab8

--- a/9.3/jdk17/Dockerfile
+++ b/9.3/jdk17/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17-jdk-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.3.9.0
 ENV JRUBY_SHA256 251e6dd8d1d2f82922c8c778d7857e1bef82fe5ca2cf77bc09356421d0b05ab8

--- a/9.3/jdk8/Dockerfile
+++ b/9.3/jdk8/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:8-jdk-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.3.9.0
 ENV JRUBY_SHA256 251e6dd8d1d2f82922c8c778d7857e1bef82fe5ca2cf77bc09356421d0b05ab8

--- a/9.3/jre11/Dockerfile
+++ b/9.3/jre11/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:11-jre-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.3.9.0
 ENV JRUBY_SHA256 251e6dd8d1d2f82922c8c778d7857e1bef82fe5ca2cf77bc09356421d0b05ab8

--- a/9.3/jre8/Dockerfile
+++ b/9.3/jre8/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:8-jre-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.3.9.0
 ENV JRUBY_SHA256 251e6dd8d1d2f82922c8c778d7857e1bef82fe5ca2cf77bc09356421d0b05ab8

--- a/9.4/jdk11/Dockerfile
+++ b/9.4/jdk11/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:11-jdk-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.4.0.0
 ENV JRUBY_SHA256 897bb8a98ad43adcbf5fd3aa75ec85b3312838c949592ca3f623dc1f569d2870

--- a/9.4/jdk17/Dockerfile
+++ b/9.4/jdk17/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17-jdk-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.4.0.0
 ENV JRUBY_SHA256 897bb8a98ad43adcbf5fd3aa75ec85b3312838c949592ca3f623dc1f569d2870

--- a/9.4/jdk8/Dockerfile
+++ b/9.4/jdk8/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:8-jdk-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.4.0.0
 ENV JRUBY_SHA256 897bb8a98ad43adcbf5fd3aa75ec85b3312838c949592ca3f623dc1f569d2870

--- a/9.4/jre11/Dockerfile
+++ b/9.4/jre11/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:11-jre-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.4.0.0
 ENV JRUBY_SHA256 897bb8a98ad43adcbf5fd3aa75ec85b3312838c949592ca3f623dc1f569d2870

--- a/9.4/jre8/Dockerfile
+++ b/9.4/jre8/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:8-jre-focal
 
-RUN apt-get update && apt-get install -y libc6-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 ENV JRUBY_VERSION 9.4.0.0
 ENV JRUBY_SHA256 897bb8a98ad43adcbf5fd3aa75ec85b3312838c949592ca3f623dc1f569d2870


### PR DESCRIPTION
**What does this PR do?**:

This PR adds GNU make to the `apt-get install` set of all `Dockerfile`s.

**Motivation**:

As discussed in #81, several gems (`ddtrace`, `bootsnap`, `stackprof`, `gvltools`) autodetect in their `extconf.rb` if they're running on JRuby, and avoid attempting to compile their native extension in that case.

Unfortunately, the "avoid attempting to compile" is implemented by writing a dummy almost-empty `Makefile`, which rubygems still tries to run. This breaks if GNU make is not installed.

GNU make is quite small, so this seems a nice improvement in user experience for users of the JRuby docker images.

**How to test the change?**:

Before:

```
$ gem install bootsnap
Fetching bootsnap-1.14.0.gem
Fetching msgpack-1.6.0-java.gem
Successfully installed msgpack-1.6.0-java
Building native extensions. This could take a while...
ERROR:  Error installing bootsnap:
	ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/bootsnap-1.14.0/ext/bootsnap
/opt/jruby/bin/jruby -I /opt/jruby/lib/ruby/stdlib -r ./siteconf20221121-34-we57cb.rb extconf.rb

current directory: /usr/local/bundle/gems/bootsnap-1.14.0/ext/bootsnap
make DESTDIR\= clean
sh: 1: exec: make: not found

current directory: /usr/local/bundle/gems/bootsnap-1.14.0/ext/bootsnap
make DESTDIR\=
sh: 1: exec: make: not found

make failed, exit code 127

Gem files will remain installed in /usr/local/bundle/gems/bootsnap-1.14.0 for inspection.
Results logged to /usr/local/bundle/extensions/universal-java-17/2.6.0/bootsnap-1.14.0/gem_make.out
```

After:

```
$ gem install bootsnap
Fetching msgpack-1.6.0-java.gem
Fetching bootsnap-1.14.0.gem
Successfully installed msgpack-1.6.0-java
Building native extensions. This could take a while...
Successfully installed bootsnap-1.14.0
2 gems installed
```

---

Fixes #81