### PR TITLE
Fix java 21 versions by upgrading to Ubuntu jammy

### DIFF
--- a/9.3/jdk21/Dockerfile
+++ b/9.3/jdk21/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jdk-focal
+FROM eclipse-temurin:21-jdk-jammy
 
 RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9.3/jre21/Dockerfile
+++ b/9.3/jre21/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-focal
+FROM eclipse-temurin:21-jre-jammy
 
 RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9.4/jdk21/Dockerfile
+++ b/9.4/jdk21/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jdk-focal
+FROM eclipse-temurin:21-jdk-jammy
 
 RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/9.4/jre21/Dockerfile
+++ b/9.4/jre21/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-focal
+FROM eclipse-temurin:21-jre-jammy
 
 RUN apt-get update && apt-get install -y libc6-dev make --no-install-recommends && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Java 21 tags for Ubuntu focal don't exist. Using the jammy version fixes this.